### PR TITLE
Fix package path

### DIFF
--- a/docs/repository/plugins.xml
+++ b/docs/repository/plugins.xml
@@ -9,7 +9,7 @@
                 <file_name>geest.0.3.6.zip</file_name>
                 <icon>icon.png</icon>
                 <author_name><![CDATA[Kartoza]]></author_name>
-                <download_url>https://github.com/worldbank/GEEST/blob/main/Geest%200.3.6/geest.0.3.6.zip</download_url>
+                <download_url>https://github.com/worldbank/GEEST/raw/refs/heads/main/Geest%200.3.6/geest.0.3.6.zip</download_url>
                 <update_date>2024-12-03 07:54:13</update_date>
                 <experimental>False</experimental>
                 <deprecated>False</deprecated>


### PR DESCRIPTION
@dragosgontariu this change should fix the plugin repo on your GEEST repo. 

You can add it to the plugin manager using this URL:

https://raw.githubusercontent.com/worldbank/GEEST/refs/heads/main/docs/repository/plugins.xml

![image](https://github.com/user-attachments/assets/752bf71c-5af9-4d97-ba17-cdf3224aceff)


CC @ClaraIV  