### PR TITLE
Change the repository name used in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
           echo " " >> docs/repository/plugins.xml 
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global --add safe.directory /__w/GEEST2/GEEST2
+          git config --global --add safe.directory /__w/GEEST/GEEST
 
           git add -A
           git commit -m "Update on plugins.xml"


### PR DESCRIPTION
Updated the used repository name from `GEEST2` to `GEEST` when preparing a package for release candidate.

This change makes sure the step responsible for updating the custom plugin staging repository uses the correct repository when creating the `plugin.xml` which is used to store information about new plugin packages.