### PR TITLE
Fix repository URL to point to worldbank/GEEST instead of kartoza/GEEST2

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -484,7 +484,7 @@ def _get_existing_releases(
     :returns: List of github releases
     :rtype: List[GithubRelease]
     """
-    base_url = "https://api.github.com/repos/" "kartoza/GEEST2/releases"
+    base_url = "https://api.github.com/repos/" "worldbank/GEEST/releases"
     response = httpx.get(base_url)
     result = []
     if response.status_code == 200:


### PR DESCRIPTION
@timlinux  Fix #117 

## Fix repository URL in release branch

  ### Problem
  The release workflow was failing because `admin.py` in the `release` branch was pointing to
  `kartoza/GEEST2` instead of `worldbank/GEEST`.

  ### Before Fix:
  main branch (admin.py → worldbank/GEEST)
      ↓ Steps 1-6: Build & upload v1.2.1 to worldbank/GEEST
  release branch (admin.py → kartoza/GEEST2) ← Workflow switches here
      ↓ Step 8: Query kartoza/GEEST2 API
      ↓ Gets: v0.5.5 (old release)
      ↓ No change to XML
      ↓ Commit fails 

  ### After Fix:
  main branch (admin.py → worldbank/GEEST)
      ↓ Steps 1-6: Build & upload v1.2.1 to worldbank/GEEST
  release branch (admin.py → worldbank/GEEST) ← Workflow switches here
      ↓ Step 8: Query worldbank/GEEST API
      ↓ Gets: v1.2.1 (just created!)
      ↓ XML updated with v1.2.1
      ↓ Commit succeeds 
