### PR TITLE
Fix CRITICAL logs flagged in ConfigurationWidgetFactory

### DIFF
--- a/geest/gui/configuration_widget_factory.py
+++ b/geest/gui/configuration_widget_factory.py
@@ -45,50 +45,53 @@ class ConfigurationWidgetFactory:
         try:
             if key == "indicator_required" and value == 0:
                 return DontUseConfigurationWidget(analysis_mode="Do Not Use", attributes=attributes)
-            if key == "use_index_score" and value == 1:
+            elif key == "use_index_score" and value == 1:
                 return IndexScoreConfigurationWidget(analysis_mode=key, attributes=attributes)
-            if key == "use_contextual_index_score" and value == 1:
+            elif key == "use_contextual_index_score" and value == 1:
                 return ContextualIndexScoreConfigurationWidget(analysis_mode=key, attributes=attributes)
-            if key == "use_index_score_with_ookla" and value == 1:
+            elif key == "use_index_score_with_ookla" and value == 1:
                 # Uses the same config widget as index score for now ...
                 return IndexScoreWithOOKLAConfigurationWidget(analysis_mode=key, attributes=attributes)
-            if key == "use_index_score_with_ghsl" and value == 1:
+            elif key == "use_index_score_with_ghsl" and value == 1:
                 # Uses the same config widget as index score for now ...
                 return IndexScoreWithGHSLConfigurationWidget(analysis_mode=key, attributes=attributes)
-            if key == "use_multi_buffer_point" and value == 1:
+            elif key == "use_multi_buffer_point" and value == 1:
                 return MultiBufferConfigurationWidget(analysis_mode=key, attributes=attributes)
-            if key == "use_single_buffer_point" and value == 1:
+            elif key == "use_single_buffer_point" and value == 1:
                 return SingleBufferConfigurationWidget(analysis_mode=key, attributes=attributes)
             # ------------------------------------------------
             # These three all use the same configuration widgets
             # but will have different datasource widgets generated as appropriate
-            if key == "use_polygon_per_cell" and value == 1:  # poly = polygon
+            elif key == "use_polygon_per_cell" and value == 1:  # poly = polygon
                 return FeaturePerCellConfigurationWidget(analysis_mode=key, attributes=attributes)
-            if key == "use_polyline_per_cell" and value == 1:
+            elif key == "use_polyline_per_cell" and value == 1:
                 return FeaturePerCellConfigurationWidget(analysis_mode=key, attributes=attributes)
-            if key == "use_osm_transport_polyline_per_cell" and value == 1:
+            elif key == "use_osm_transport_polyline_per_cell" and value == 1:
                 return OsmTransportConfigurationWidget(analysis_mode=key, attributes=attributes)
-            if key == "use_point_per_cell" and value == 1:
+            elif key == "use_point_per_cell" and value == 1:
                 return FeaturePerCellConfigurationWidget(analysis_mode=key, attributes=attributes)
-            if key == "use_csv_to_point_layer" and value == 1:
+            elif key == "use_csv_to_point_layer" and value == 1:
                 return AcledCsvConfigurationWidget(analysis_mode=key, attributes=attributes)
             # ------------------------------------------------
-            if key == "use_classify_polygon_into_classes" and value == 1:
+            elif key == "use_classify_polygon_into_classes" and value == 1:
                 return ClassifiedPolygonConfigurationWidget(analysis_mode=key, attributes=attributes)
-            if key == "use_classify_safety_polygon_into_classes" and value == 1:
+            elif key == "use_classify_safety_polygon_into_classes" and value == 1:
                 return SafetyPolygonConfigurationWidget(analysis_mode=key, attributes=attributes)
-            if key == "use_nighttime_lights" and value == 1:
+            elif key == "use_nighttime_lights" and value == 1:
                 return SafetyRasterConfigurationWidget(analysis_mode=key, attributes=attributes)
-            if key == "use_environmental_hazards" and value == 1:
+            elif key == "use_environmental_hazards" and value == 1:
                 return RasterReclassificationConfigurationWidget(analysis_mode=key, attributes=attributes)
-            if key == "use_street_lights" and value == 1:
+            elif key == "use_street_lights" and value == 1:
                 return StreetLightsConfigurationWidget(analysis_mode=key, attributes=attributes)
             else:
-                log_message(
-                    f"Factory did not match any widgets for key: {key}",
-                    tag="Geest",
-                    level=Qgis.Critical,
-                )
+                # Return None for disabled modes (value=0) or unrecognized keys
+                # Only log CRITICAL if value=1 but key is unrecognized (truly unknown mode)
+                if value == 1:
+                    log_message(
+                        f"Factory did not match any widgets for key: {key}",
+                        tag="Geest",
+                        level=Qgis.Critical,
+                    )
                 return None
         except Exception as e:
             log_message(f"Error in create_radio_button: {e}", level=Qgis.Critical)


### PR DESCRIPTION
Fixes #132

Fixes a logic bug where disabled analysis modes (value=0) were incorrectly logging CRITICAL errors.

Changes:
- Convert independent `if` statements to `elif` chain in create_widget()
- Update else clause to only log CRITICAL when value=1 AND key is unrecognized
- Disabled modes now return None silently (expected behavior)

Eliminates 10 false CRITICAL log messages on startup while preserving error detection for truly unknown analysis modes