### PR TITLE
Add filtering for study areas without GHSL settlements

### DIFF
--- a/geest/core/tasks/study_area_processing_task.py
+++ b/geest/core/tasks/study_area_processing_task.py
@@ -641,7 +641,7 @@ class StudyAreaProcessingTask(QgsTask):
         if filter_enabled and not intersects_ghsl:
             log_message(
                 f"Skipping {normalized_name} - no GHSL settlements found (filter_study_areas_by_ghsl=True)",
-                level="INFO"
+                level="INFO",
             )
             # Update progress counter and return early
             self.counter += 1


### PR DESCRIPTION

https://github.com/user-attachments/assets/35908307-319c-4726-b0dc-2f4b6da56385

Logs:

```
# for part that instersects ghsl
2025-12-05 13:00:45,519 [INFO] [geest.core.tasks.study_area_processing_task: 633] alb_part0 intersects GHSL: True
2025-12-05 13:00:45,700 [INFO] [geest.core.tasks.study_area_processing_task: 580] Updated processing status flag for geometry_processed for alb_part0 to 1.
2025-12-05 13:00:45,700 [INFO] [geest.core.tasks.study_area_processing_task: 654] Creating vector grid for alb_part0.
2025-12-05 13:00:45,837 [INFO] [geest.core.tasks.grid_chunker_task: 201] Processing chunk (x) 0 of 1521
2025-12-05 13:00:45,837 [INFO] [geest.core.tasks.grid_chunker_task: 208] Processing chunk (y) 0 of 3365

...

# for part that doesn't instersect ghsl
2025-12-05 13:08:54,590 [INFO] [geest.core.tasks.study_area_processing_task: 633] alb_part4 intersects GHSL: False
2025-12-05 13:08:54,699 [INFO] [geest.core.tasks.study_area_processing_task: 580] Updated processing status flag for geometry_processed for alb_part4 to 1.
2025-12-05 13:08:54,700 [DEBUG] [geest.core.tasks.study_area_processing_task: 642] Skipping alb_part4 - no GHSL settlements found (filter_study_areas_by_ghsl=True)
2025-12-05 13:08:54,700 [INFO] [geest.core.tasks.study_area_processing_task: 650] XXXXXXXXXXXX   Progress: 100% XXXXXXXXXXXXXXXXXXXXXXX
```