### PR TITLE
Incorrect methodology for Safety

### DIFF
--- a/geest/core/workflows/street_lights_buffer_workflow.py
+++ b/geest/core/workflows/street_lights_buffer_workflow.py
@@ -95,12 +95,13 @@ class StreetLightsBufferWorkflow(WorkflowBase):
             self.attributes["error"] = error
             raise Exception(error)
 
-        if analysis_scale == "local":
-            self.buffer_distance = 20  # 20m buffer
-
-            self.buffer_distance = 565  # 565m buffer for global
-        else:
-            raise
+        # if analysis_scale == "local":
+        #     self.buffer_distance = 20  # 20m buffer for local analysis
+        # else:
+        #     # National (and any other scale): 1000m (1km) buffer as per methodology
+        #     self.buffer_distance = 1000
+        # For now, using 1000m (1km) buffer for all scales as per methodology
+        self.buffer_distance = 1000
 
     def _process_features_for_area(
         self,
@@ -125,9 +126,9 @@ class StreetLightsBufferWorkflow(WorkflowBase):
 
         # Step 1: Buffer the selected features
         buffered_layer = self._buffer_features(area_features, f"{self.layer_id}_buffered_{index}")
-        # Step 2: Select grid cells that intersect with features
+        # Step 2: Select grid cells that intersect with buffered features (1km buffer)
         output_path = os.path.join(self.workflow_directory, f"{self.layer_id}_grid_cells.gpkg")
-        area_grid = select_grid_cells_and_count_features(self.grid_layer, area_features, output_path, self.feedback)
+        area_grid = select_grid_cells_and_count_features(self.grid_layer, buffered_layer, output_path, self.feedback)
 
         # Step 3: Assign scores to the grid layer
         grid_layer = self._score_grid(area_grid, buffered_layer)


### PR DESCRIPTION
Fixes #191

The street lights analysis was not producing the expected 1km buffer coverage due to two bugs:         

  1. Buffer distance bug: set buffer_distance = 20 for local analysis, but line   
  101 immediately overwrote it unconditionally to 565. Neither value matched the methodology requirement 
  of 1000m (1km).

  2. Grid selection bug: The workflow was using area_features (original street light points)  
  instead of buffered_layer when selecting grid cells. This meant only cells intersecting the actual     
  points were scored, not all cells within the 1km buffer zone.

Fix:
                                                                                                         
  1. Set buffer_distance = 1000 (1km) for all analysis scales as per methodology                         
  2. Changed to use buffered_layer instead of area_features in                                  
  select_grid_cells_and_count_features()

From:
<img width="752" height="693" alt="Screenshot From 2026-01-11 14-34-46" src="https://github.com/user-attachments/assets/4495c18a-b326-4cb2-8e5b-2bdae47ee13f" />
<img width="752" height="693" alt="Screenshot From 2026-01-11 14-36-18" src="https://github.com/user-attachments/assets/9b44a89a-5dda-48c1-8dff-729953ba90b8" />

To:
<img width="752" height="693" alt="Screenshot From 2026-01-11 14-41-46" src="https://github.com/user-attachments/assets/1440f127-dbd9-403e-adb5-a9a4e0708f12" />
