### PR TITLE
Configure logo does not show on indicators

### DIFF
--- a/geest/core/json_tree_item.py
+++ b/geest/core/json_tree_item.py
@@ -525,6 +525,10 @@ class JsonTreeItem:
                 "use_index_score",
                 "use_index_score_with_ookla",
                 "use_environmental_hazards",
+                "use_contextual_index_score",  # Contextual indicators don't use vector layers
+                "use_eplex_score",  # EPLex indicators don't use vector layers
+                "use_index_score_with_ghsl",  # GHSL indicators use raster, not vector
+                "use_nighttime_lights",  # Nighttime lights use raster, not vector
             ]:
                 if not data.get(qgis_layer_source_key, False) and not data.get(qgis_layer_shapefile_key, False):
                     return "Not configured (optional)"

--- a/geest/resources/icons/not-configured.svg
+++ b/geest/resources/icons/not-configured.svg
@@ -14,21 +14,11 @@
   <g
      id="layer1">
     <ellipse
-       style="fill:#FF7700;fill-opacity:1;stroke:none;stroke-width:10.9268;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#FFBA00;fill-opacity:1;stroke:none;stroke-width:10.9268;stroke-dasharray:none;stroke-opacity:1"
        id="path4"
        cx="34.139038"
        cy="34.100826"
        rx="33.01112"
        ry="33.059422" />
-    <text
-       x="34.139038"
-       y="52"
-       font-size="65"
-       font-weight="bold"
-       text-anchor="middle"
-       fill="#ffffff"
-       style="font-family: Arial, sans-serif;">
-      c
-    </text>
   </g>
 </svg>

--- a/geest/resources/icons/not-run.svg
+++ b/geest/resources/icons/not-run.svg
@@ -14,11 +14,21 @@
   <g
      id="layer1">
     <ellipse
-       style="fill:#FFBA00;fill-opacity:1;stroke:none;stroke-width:10.9268;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#FF7700;fill-opacity:1;stroke:none;stroke-width:10.9268;stroke-dasharray:none;stroke-opacity:1"
        id="path4"
        cx="34.139038"
        cy="34.100826"
        rx="33.01112"
        ry="33.059422" />
+    <text
+       x="34.139038"
+       y="52"
+       font-size="65"
+       font-weight="bold"
+       text-anchor="middle"
+       fill="#ffffff"
+       style="font-family: Arial, sans-serif;">
+      c
+    </text>
   </g>
 </svg>


### PR DESCRIPTION
Fixes #243

1.
Added 4 analysis modes to the exclusion list that skips vector layer source validation. These modes use alternative inputs (index scores, raster files) instead of vector layers, so checking for vector layer sources was incorrectly marking them as "Not configured" even when they had valid configuration.

2.
swapped naming:  not-configured.svg (orange "c")  not-run.svg (empty yellow)


https://github.com/user-attachments/assets/6432019e-9aa5-46e1-b231-60230026c616


https://github.com/user-attachments/assets/f7756618-7f1f-44db-984b-4d46b9e8c0ea

