### PR TITLE
Add project-local Neovim configuration with WhichKey menu

### DIFF
--- a/.nvim.lua
+++ b/.nvim.lua
@@ -1,0 +1,239 @@
+-- GEEST nvim project configuration
+-- Auto-sourced by nvim when exrc is enabled, or source manually with:
+--   :source .nvim.lua
+
+-- Guard against re-sourcing
+if vim.g.geest_loaded then
+  return
+end
+vim.g.geest_loaded = true
+
+-- Helper to run commands in a floating terminal
+local function float_term(cmd, opts)
+  opts = opts or {}
+  local buf = vim.api.nvim_create_buf(false, true)
+  local width = opts.width or math.floor(vim.o.columns * 0.8)
+  local height = opts.height or math.floor(vim.o.lines * 0.8)
+  local row = math.floor((vim.o.lines - height) / 2)
+  local col = math.floor((vim.o.columns - width) / 2)
+
+  local win = vim.api.nvim_open_win(buf, true, {
+    relative = 'editor',
+    width = width,
+    height = height,
+    row = row,
+    col = col,
+    style = 'minimal',
+    border = 'rounded',
+    title = opts.title or ' Terminal ',
+    title_pos = 'center',
+  })
+
+  if cmd then
+    vim.fn.termopen(cmd, {
+      on_exit = function(_, exit_code)
+        if opts.close_on_success and exit_code == 0 then
+          vim.defer_fn(function()
+            if vim.api.nvim_win_is_valid(win) then
+              vim.api.nvim_win_close(win, true)
+            end
+          end, 1000)
+        end
+      end,
+    })
+  else
+    vim.fn.termopen(vim.o.shell)
+  end
+  vim.cmd('startinsert')
+end
+
+-- Project-specific commands
+vim.api.nvim_create_user_command('GeestQgis', function()
+  float_term('GEEST_DEBUG=0 GEEST_EXPERIMENTAL=0 RUNNING_ON_LOCAL=1 nix run .#default -- --profile GEEST2', { title = ' QGIS ' })
+end, { desc = 'Launch QGIS (normal mode)' })
+
+vim.api.nvim_create_user_command('GeestQgisDebug', function()
+  float_term('GEEST_DEBUG=1 GEEST_EXPERIMENTAL=0 RUNNING_ON_LOCAL=1 nix run .#default -- --profile GEEST2', { title = ' QGIS Debug ' })
+end, { desc = 'Launch QGIS (debug mode)' })
+
+vim.api.nvim_create_user_command('GeestQgisExperimental', function()
+  float_term('GEEST_DEBUG=0 GEEST_EXPERIMENTAL=1 RUNNING_ON_LOCAL=1 nix run .#default -- --profile GEEST2', { title = ' QGIS Experimental ' })
+end, { desc = 'Launch QGIS (experimental features)' })
+
+vim.api.nvim_create_user_command('GeestQgisLtr', function()
+  float_term('RUNNING_ON_LOCAL=1 nix run .#qgis-ltr', { title = ' QGIS LTR ' })
+end, { desc = 'Launch QGIS LTR' })
+
+vim.api.nvim_create_user_command('GeestPrecommit', function()
+  float_term('pre-commit run --all-files', { title = ' Pre-commit ' })
+end, { desc = 'Run pre-commit checks' })
+
+vim.api.nvim_create_user_command('GeestPrecommitStaged', function()
+  float_term('pre-commit run', { title = ' Pre-commit (staged) ' })
+end, { desc = 'Run pre-commit on staged files' })
+
+vim.api.nvim_create_user_command('GeestTests', function()
+  float_term('./scripts/run-tests.sh', { title = ' Tests ' })
+end, { desc = 'Run tests' })
+
+vim.api.nvim_create_user_command('GeestClean', function()
+  float_term('./scripts/clean.sh', { title = ' Clean ' })
+end, { desc = 'Clean build artifacts' })
+
+vim.api.nvim_create_user_command('GeestRemovePycache', function()
+  float_term('./scripts/remove_pycache.sh', { title = ' Remove __pycache__ ' })
+end, { desc = 'Remove __pycache__ directories' })
+
+vim.api.nvim_create_user_command('GeestDocstrings', function()
+  float_term('./scripts/docstrings_check.sh', { title = ' Docstrings Check ' })
+end, { desc = 'Check docstrings' })
+
+vim.api.nvim_create_user_command('GeestEncoding', function()
+  float_term('./scripts/encoding_check.sh', { title = ' Encoding Check ' })
+end, { desc = 'Check file encodings' })
+
+vim.api.nvim_create_user_command('GeestGource', function()
+  float_term('./scripts/gource.sh', { title = ' Gource ' })
+end, { desc = 'Run gource visualization' })
+
+vim.api.nvim_create_user_command('GeestCompileStrings', function()
+  float_term('./scripts/compile-strings.sh', { title = ' Compile Strings ' })
+end, { desc = 'Compile translation strings' })
+
+vim.api.nvim_create_user_command('GeestUpdateStrings', function()
+  float_term('./scripts/update-strings.sh', { title = ' Update Strings ' })
+end, { desc = 'Update translation strings' })
+
+vim.api.nvim_create_user_command('GeestTerm', function()
+  float_term(nil, { title = ' Terminal ' })
+end, { desc = 'Open floating terminal' })
+
+vim.api.nvim_create_user_command('GeestGitStatus', function()
+  float_term('git status && echo "\\n--- Recent commits ---\\n" && git log --oneline -10', { title = ' Git Status ' })
+end, { desc = 'Git status and recent commits' })
+
+vim.api.nvim_create_user_command('GeestGitDiff', function()
+  float_term('git diff', { title = ' Git Diff ' })
+end, { desc = 'Git diff' })
+
+vim.api.nvim_create_user_command('GeestGitLog', function()
+  float_term('git log --oneline --graph --decorate -30', { title = ' Git Log ' })
+end, { desc = 'Git log (graph)' })
+
+vim.api.nvim_create_user_command('GeestLazygit', function()
+  float_term('lazygit', { title = ' Lazygit ' })
+end, { desc = 'Open lazygit' })
+
+-- Build & Release commands
+vim.api.nvim_create_user_command('GeestBuild', function()
+  float_term('python admin.py build', { title = ' Build Plugin ' })
+end, { desc = 'Build plugin to build/' })
+
+vim.api.nvim_create_user_command('GeestGenerateZip', function()
+  float_term('python admin.py generate-zip', { title = ' Generate ZIP ' })
+end, { desc = 'Generate plugin ZIP' })
+
+vim.api.nvim_create_user_command('GeestInstall', function()
+  float_term('python admin.py --qgis-profile GEEST2 install', { title = ' Install Plugin ' })
+end, { desc = 'Install plugin to QGIS profile' })
+
+vim.api.nvim_create_user_command('GeestUninstall', function()
+  float_term('python admin.py --qgis-profile GEEST2 uninstall', { title = ' Uninstall Plugin ' })
+end, { desc = 'Uninstall plugin from QGIS profile' })
+
+vim.api.nvim_create_user_command('GeestSymlink', function()
+  float_term('python admin.py --qgis-profile GEEST2 symlink', { title = ' Symlink Plugin ' })
+end, { desc = 'Symlink plugin to QGIS profile' })
+
+vim.api.nvim_create_user_command('GeestGenerateRepoXml', function()
+  float_term('python admin.py generate-plugin-repo-xml', { title = ' Generate Repo XML ' })
+end, { desc = 'Generate plugin repository XML' })
+
+vim.api.nvim_create_user_command('GeestBundleDeps', function()
+  float_term('python admin.py bundle-deps', { title = ' Bundle Dependencies ' })
+end, { desc = 'Bundle vendored dependencies (h3, etc.)' })
+
+vim.api.nvim_create_user_command('GeestCleanExtlibs', function()
+  float_term('python admin.py clean-extlibs', { title = ' Clean Extlibs ' })
+end, { desc = 'Clean vendored dependencies' })
+
+vim.api.nvim_create_user_command('GeestReleaseDraft', function()
+  float_term('gh release create --draft --generate-notes', { title = ' Draft Release ' })
+end, { desc = 'Create draft GitHub release' })
+
+vim.api.nvim_create_user_command('GeestReleaseList', function()
+  float_term('gh release list', { title = ' Releases ' })
+end, { desc = 'List GitHub releases' })
+
+vim.api.nvim_create_user_command('GeestTagList', function()
+  float_term('git tag -l --sort=-v:refname | head -20', { title = ' Tags ' })
+end, { desc = 'List recent tags' })
+
+vim.api.nvim_create_user_command('GeestTagCreate', function()
+  vim.ui.input({ prompt = 'Tag version (e.g., v2.0.1): ' }, function(tag)
+    if tag and tag ~= '' then
+      vim.ui.input({ prompt = 'Tag message: ' }, function(msg)
+        if msg and msg ~= '' then
+          float_term(string.format('git tag -a %s -m "%s" && echo "Tag %s created. Push with: git push origin %s"', tag, msg, tag, tag), { title = ' Create Tag ' })
+        end
+      end)
+    end
+  end)
+end, { desc = 'Create annotated tag' })
+
+-- Register with which-key under <leader>p (Project)
+local wk_ok, wk = pcall(require, 'which-key')
+if wk_ok then
+  wk.add({
+    { '<leader>p', group = 'Project' },
+    -- QGIS launchers
+    { '<leader>pq', group = 'QGIS' },
+    { '<leader>pqq', '<cmd>GeestQgis<cr>', desc = 'Launch QGIS' },
+    { '<leader>pqd', '<cmd>GeestQgisDebug<cr>', desc = 'Launch QGIS (debug)' },
+    { '<leader>pqe', '<cmd>GeestQgisExperimental<cr>', desc = 'Launch QGIS (experimental)' },
+    { '<leader>pql', '<cmd>GeestQgisLtr<cr>', desc = 'Launch QGIS LTR' },
+    -- Pre-commit / Quality
+    { '<leader>pc', group = 'Checks' },
+    { '<leader>pcc', '<cmd>GeestPrecommit<cr>', desc = 'Pre-commit (all files)' },
+    { '<leader>pcs', '<cmd>GeestPrecommitStaged<cr>', desc = 'Pre-commit (staged)' },
+    { '<leader>pcd', '<cmd>GeestDocstrings<cr>', desc = 'Check docstrings' },
+    { '<leader>pce', '<cmd>GeestEncoding<cr>', desc = 'Check encodings' },
+    -- Tests
+    { '<leader>pt', '<cmd>GeestTests<cr>', desc = 'Run tests' },
+    -- Clean
+    { '<leader>px', group = 'Clean' },
+    { '<leader>pxc', '<cmd>GeestClean<cr>', desc = 'Clean build artifacts' },
+    { '<leader>pxp', '<cmd>GeestRemovePycache<cr>', desc = 'Remove __pycache__' },
+    -- Translations
+    { '<leader>pi', group = 'i18n' },
+    { '<leader>pic', '<cmd>GeestCompileStrings<cr>', desc = 'Compile strings' },
+    { '<leader>piu', '<cmd>GeestUpdateStrings<cr>', desc = 'Update strings' },
+    -- Git
+    { '<leader>pg', group = 'Git' },
+    { '<leader>pgs', '<cmd>GeestGitStatus<cr>', desc = 'Status + recent commits' },
+    { '<leader>pgd', '<cmd>GeestGitDiff<cr>', desc = 'Diff' },
+    { '<leader>pgl', '<cmd>GeestGitLog<cr>', desc = 'Log (graph)' },
+    { '<leader>pgg', '<cmd>GeestLazygit<cr>', desc = 'Lazygit' },
+    -- Build & Package
+    { '<leader>pb', group = 'Build' },
+    { '<leader>pbb', '<cmd>GeestBuild<cr>', desc = 'Build plugin' },
+    { '<leader>pbz', '<cmd>GeestGenerateZip<cr>', desc = 'Generate ZIP' },
+    { '<leader>pbi', '<cmd>GeestInstall<cr>', desc = 'Install to QGIS' },
+    { '<leader>pbu', '<cmd>GeestUninstall<cr>', desc = 'Uninstall from QGIS' },
+    { '<leader>pbs', '<cmd>GeestSymlink<cr>', desc = 'Symlink to QGIS' },
+    { '<leader>pbx', '<cmd>GeestGenerateRepoXml<cr>', desc = 'Generate repo XML' },
+    { '<leader>pbd', '<cmd>GeestBundleDeps<cr>', desc = 'Bundle dependencies' },
+    { '<leader>pbc', '<cmd>GeestCleanExtlibs<cr>', desc = 'Clean extlibs' },
+    -- Release
+    { '<leader>pr', group = 'Release' },
+    { '<leader>prd', '<cmd>GeestReleaseDraft<cr>', desc = 'Draft GitHub release' },
+    { '<leader>prl', '<cmd>GeestReleaseList<cr>', desc = 'List releases' },
+    { '<leader>prt', '<cmd>GeestTagList<cr>', desc = 'List tags' },
+    { '<leader>prn', '<cmd>GeestTagCreate<cr>', desc = 'Create new tag' },
+    -- Misc
+    { '<leader>pv', '<cmd>GeestGource<cr>', desc = 'Gource visualization' },
+    { '<leader>pp', '<cmd>GeestTerm<cr>', desc = 'Floating terminal' },
+  })
+end
+
+vim.notify("GEEST: Project commands and <leader>p menu loaded", vim.log.levels.INFO)


### PR DESCRIPTION
## Summary
- Adds `.nvim.lua` with `<leader>p` project menu for development workflow
- All commands run in floating terminals for seamless Neovim workflow
- Requires `exrc` enabled or manual `:source .nvim.lua`

### Menu structure:
| Key | Submenu | Description |
|-----|---------|-------------|
| `pq` | QGIS | Launch QGIS (normal/debug/experimental/LTR) |
| `pc` | Checks | Pre-commit, docstrings, encoding |
| `pt` | | Run tests |
| `px` | Clean | Clean build artifacts, pycache |
| `pi` | i18n | Compile/update translation strings |
| `pg` | Git | Status, diff, log, lazygit |
| `pb` | Build | Build, ZIP, install, symlink, repo XML |
| `pr` | Release | Draft release, list releases/tags, create tag |
| `pv` | | Gource visualization |
| `pp` | | Floating terminal |

## Test plan
- [ ] Open Neovim in project root
- [ ] Run `:source .nvim.lua` or enable `exrc`
- [ ] Press `<leader>p` to see WhichKey menu
- [ ] Test QGIS launch with `<leader>pqq`
- [ ] Test floating terminal with `<leader>pp`