### PR TITLE
Trap workflow start-up errors: failed status icon, accessible tooltip, run continues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A broken or missing data source on one indicator no longer aborts a
+  multi-indicator run with a raw Python traceback: workflow start-up
+  errors are trapped at the queue boundary, the indicator's status icon
+  flips to failed with an accessible explanation in its tooltip, and the
+  rest of the queue continues. The known config-validation raises
+  (multi-buffer, point-per-cell, OSM transport) now produce plain-language
+  messages.
 - GHSL tile download failures now raise a descriptive `GhslDownloadError`
   instead of surfacing later as a bare `FileNotFoundError` from zipfile;
   corrupt cached zips are removed so the next attempt re-downloads. The

--- a/geest/core/workflow_queue_manager.py
+++ b/geest/core/workflow_queue_manager.py
@@ -4,6 +4,7 @@
 This module contains functionality for workflow queue manager.
 """
 
+import traceback
 from typing import Optional
 
 from qgis.core import Qgis, QgsProcessingContext, QgsProject, QgsTask
@@ -109,11 +110,41 @@ class WorkflowQueueManager(QObject):
                 tag="GeoE3",
                 level=Qgis.Warning,
             )
+            self._mark_item_errored(item, str(error))
             self.processing_error.emit(str(error))
+            return None
+        except Exception as error:  # one broken indicator must never abort the run
+            log_message(
+                f"Could not create workflow for {item.attribute('id', item.guid)}: {error}\n"
+                f"{traceback.format_exc()}",
+                tag="GeoE3",
+                level=Qgis.Critical,
+            )
+            message = (
+                f"This indicator could not be started ({error}). "
+                "Check its data source configuration and run it again."
+            )
+            self._mark_item_errored(item, message)
+            self.processing_error.emit(message)
             return None
         self.workflow_queue.add_job(task)
         log_message(f"Task added: {task.description()}")
         return task
+
+    @staticmethod
+    def _mark_item_errored(item: JsonTreeItem, message: str) -> None:
+        """Record a start failure on the tree item.
+
+        Setting ``result`` to an error marker flips the item's status to
+        "Workflow failed" (red icon) and ``error`` becomes its tooltip, so
+        the user can see which indicator needs attention and why while the
+        rest of the run continues.
+        """
+        try:
+            item.setAttribute("result", "Workflow Error")
+            item.setAttribute("error", message)
+        except Exception:  # nosec B110 — display bookkeeping must never raise
+            pass
 
     def start_processing(self) -> None:
         """Start processing the tasks in the WorkflowQueue."""

--- a/geest/core/workflows/multi_buffer_distances_native_workflow.py
+++ b/geest/core/workflows/multi_buffer_distances_native_workflow.py
@@ -35,7 +35,7 @@ from geest.core.grid_column_utils import (
 from geest.core.workflows.mappings import MAPPING_REGISTRY
 from geest.utilities import log_message
 
-from .workflow_base import WorkflowBase
+from .workflow_base import WorkflowBase, WorkflowNotConfiguredError
 
 
 class MultiBufferDistancesNativeWorkflow(WorkflowBase):
@@ -136,7 +136,9 @@ class MultiBufferDistancesNativeWorkflow(WorkflowBase):
                     tag="GeoE3",
                     level=Qgis.Warning,
                 )
-                raise Exception("Invalid points layer found.")
+                raise WorkflowNotConfiguredError(
+                    "No point layer is set for this indicator. Open its data source settings and choose a point layer."
+                )
         log_message(f"Using points layer at {layer_path}")
         self.features_layer = QgsVectorLayer(layer_path, "points", "ogr")
         if not self.features_layer.isValid():
@@ -182,9 +184,10 @@ class MultiBufferDistancesNativeWorkflow(WorkflowBase):
                     tag="GeoE3",
                     level=Qgis.Critical,
                 )
-                raise Exception(
-                    f"Points layer not found. If you used a temporary QuickOSM layer, "
-                    "ensure it is still loaded in QGIS before running the workflow."
+                raise WorkflowNotConfiguredError(
+                    "The point layer for this indicator could not be opened. If it was a temporary "
+                    "layer (e.g. from QuickOSM), load it in QGIS again or re-select a saved layer in "
+                    "the indicator's data source settings."
                 )
         mode = self.attributes.get("multi_buffer_travel_mode", "Walking")
         self.mode = None

--- a/geest/core/workflows/osm_transport_polyline_per_cell_workflow.py
+++ b/geest/core/workflows/osm_transport_polyline_per_cell_workflow.py
@@ -19,7 +19,7 @@ from geest.core.algorithms.features_per_cell_processor import select_grid_cells_
 from geest.core.osm_downloaders import OSMDownloadType
 from geest.utilities import log_message
 
-from .workflow_base import WorkflowBase
+from .workflow_base import WorkflowBase, WorkflowNotConfiguredError
 
 
 class OsmTransportPolylinePerCellWorkflow(WorkflowBase):
@@ -73,7 +73,7 @@ class OsmTransportPolylinePerCellWorkflow(WorkflowBase):
                 if not layer_path:
                     error_msg = "No transport layer found. Please configure a data source or download the active transport network."
                     log_message(error_msg, tag="GeoE3", level=Qgis.Critical)
-                    raise ValueError(error_msg)
+                    raise WorkflowNotConfiguredError(error_msg)
         self.features_layer = QgsVectorLayer(layer_path, "OSM Transport Layer", "ogr")
 
     def _process_features_for_area(

--- a/geest/core/workflows/point_per_cell_workflow.py
+++ b/geest/core/workflows/point_per_cell_workflow.py
@@ -27,7 +27,7 @@ from geest.core.grid_column_utils import (
 )
 from geest.utilities import log_message
 
-from .workflow_base import WorkflowBase
+from .workflow_base import WorkflowBase, WorkflowNotConfiguredError
 
 
 class PointPerCellWorkflow(WorkflowBase):
@@ -64,33 +64,25 @@ class PointPerCellWorkflow(WorkflowBase):
         if not layer_path:
             layer_path = self.attributes.get("point_per_cell_layer_source", None)
             if not layer_path:
-                error = "No point per cell layer provided."
-                self.attributes["error"] = error
-                # Raise an exception using our error message
-                raise Exception(error)
-        try:
+                raise WorkflowNotConfiguredError(
+                    "No point layer is set for this indicator. Open its data source settings and choose a point layer."
+                )
+        log_message(
+            f"Loading point per cell layer: {layer_path}",
+            tag="GeoE3",
+            level=Qgis.Info,
+        )
+        self.features_layer = QgsVectorLayer(layer_path, "point_per_cell_layer", "ogr")
+        if not self.features_layer.isValid():
             log_message(
-                f"Loading point per cell layer: {layer_path}",
-                tag="GeoE3",
-                level=Qgis.Info,
-            )
-            self.features_layer = QgsVectorLayer(layer_path, "point_per_cell_layer", "ogr")
-            if not self.features_layer.isValid():
-                error = f"Point per cell layer is not valid: {layer_path}"
-                self.attributes["error"] = error
-                self.attributes["result"] = f"{self.workflow_name} Workflow Failed"
-                raise Exception(error)
-        except Exception as e:
-            log_message(
-                f"Error loading point per cell layer: {str(e)}",
+                f"Point per cell layer is not valid: {layer_path}",
                 tag="GeoE3",
                 level=Qgis.Critical,
             )
-            error = f"Error loading point per cell layer: {str(e)}"
-            self.attributes["error"] = error
-            self.attributes["result"] = f"{self.workflow_name} Workflow Failed"
-
-            raise Exception(error)
+            raise WorkflowNotConfiguredError(
+                f"The point layer for this indicator could not be opened ({layer_path}). "
+                "Re-select the data source in the indicator's settings."
+            )
         self.feedback.setProgress(1.0)
         self.workflow_name = "point_per_cell"
         self.supports_empty_features_fallback = True

--- a/geest/gui/panels/tree_panel.py
+++ b/geest/gui/panels/tree_panel.py
@@ -2005,13 +2005,16 @@ class TreePanel(QWidget):
             attributes["analysis_mode"] = "analysis_aggregation"
         task = self.queue_manager.add_workflow(item, self.cell_size_m(), self.analysis_scale())
         if task is None:
-            # The workflow declined the job (e.g. data source not configured).
+            # The workflow declined the job (data source missing or broken).
+            # The queue manager has already marked the item (failed icon and
+            # error tooltip); repaint so that is visible, tell the user in
+            # plain language, and let the rest of the run continue.
+            reason = item.attribute("error", "") or tr("configure its data source and run it again.")
+            self.treeView.viewport().update()
             try:
                 iface.messageBar().pushMessage(
                     tr("GeoE3"),
-                    tr("'{name}' was skipped — configure its data source and run it again.").format(
-                        name=item.attribute("id", item.guid)
-                    ),
+                    tr("'{name}' was skipped — {reason}").format(name=item.attribute("id", item.guid), reason=reason),
                     level=Qgis.Warning,
                     duration=10,
                 )

--- a/test/test_workflow_job_e2e.py
+++ b/test/test_workflow_job_e2e.py
@@ -23,10 +23,26 @@ from geest.core.workflow_queue_manager import WorkflowQueueManager  # noqa: E402
 
 
 def make_indicator(attributes):
-    """Build a minimal analysis→dimension→factor→indicator chain."""
-    analysis = JsonTreeItem({"id": "analysis_1"}, role="analysis", parent=None)
-    dimension = JsonTreeItem({"id": "dimension_1"}, role="dimension", parent=analysis)
-    factor = JsonTreeItem({"id": "factor_1"}, role="factor", parent=dimension)
+    """Build a minimal analysis→dimension→factor→indicator chain.
+
+    Parents carry non-zero weightings so status checks do not classify the
+    indicator as "Excluded from analysis".
+    """
+    analysis = JsonTreeItem(
+        ["E2E analysis", "Configured", 1.0, {"id": "analysis_1"}],
+        role="analysis",
+        parent=None,
+    )
+    dimension = JsonTreeItem(
+        ["E2E dimension", "Configured", 1.0, {"id": "dimension_1", "analysis_weighting": 1.0}],
+        role="dimension",
+        parent=analysis,
+    )
+    factor = JsonTreeItem(
+        ["E2E factor", "Configured", 1.0, {"id": "factor_1", "dimension_weighting": 1.0}],
+        role="factor",
+        parent=dimension,
+    )
     data = ["E2E indicator", "Configured", 1.0, attributes]
     return JsonTreeItem(data, role="indicator", parent=factor)
 
@@ -110,6 +126,71 @@ class TestWorkflowJobEndToEnd(unittest.TestCase):
         manager = WorkflowQueueManager(pool_size=1)
         job = manager.add_workflow(item, cell_size_m=1000.0, analysis_scale="local")
         self.assertIsNone(job, "unconfigured indicator must be declined by the queue")
+
+    def test_broken_layer_marks_item_failed_and_run_continues(self):
+        """A broken data source marks the item failed; the run continues.
+
+        Regression for the field crash 'Exception: Invalid points layer
+        found.' aborting run_all: the declined item must carry the failed
+        status (red icon) and an accessible error tooltip, and the next
+        indicator in a multi-indicator run must still be accepted.
+        """
+        broken = make_indicator(
+            {
+                "analysis_mode": "use_multi_buffer_point",
+                "id": "e2e_broken_layer",
+                "factor_weighting": 1.0,
+                "description": "E2E broken layer",
+                "result": "Not Run",
+                "multi_buffer_travel_distances": "100,200",
+                "multi_buffer_point_shapefile": "/nonexistent/points.shp",
+            }
+        )
+        manager = WorkflowQueueManager(pool_size=1)
+        job = manager.add_workflow(broken, cell_size_m=1000.0, analysis_scale="local")
+        self.assertIsNone(job, "broken indicator must be declined, not raise")
+        self.assertEqual(broken.getStatus(), "Workflow failed")
+        error_text = broken.attribute("error", "")
+        self.assertTrue(error_text, "declined item must carry an error message for its tooltip")
+        self.assertNotIn("Traceback", error_text, "tooltip must be accessible language, not a traceback")
+
+        # The rest of a multi-indicator run continues: a valid indicator is
+        # still accepted by the same queue manager afterwards.
+        points = os.path.join(os.path.dirname(__file__), "test_data", "points", "points.shp")
+        healthy = make_indicator(
+            {
+                "analysis_mode": "use_point_per_cell",
+                "id": "e2e_healthy_after_broken",
+                "description": "E2E healthy indicator",
+                "result": "Not Run",
+                "point_per_cell_shapefile": points,
+            }
+        )
+        job = manager.add_workflow(healthy, cell_size_m=1000.0, analysis_scale="local")
+        self.assertIsNotNone(job, "a healthy indicator must still queue after a broken one")
+
+    def test_unexpected_exception_is_trapped_not_propagated(self):
+        """Even a non-WorkflowNotConfiguredError must not abort queueing."""
+        from unittest import mock
+
+        item = make_indicator(
+            {
+                "analysis_mode": "use_point_per_cell",
+                "id": "e2e_unexpected_boom",
+                "factor_weighting": 1.0,
+                "description": "E2E unexpected exception",
+                "result": "Not Run",
+            }
+        )
+        manager = WorkflowQueueManager(pool_size=1)
+        with mock.patch(
+            "geest.core.workflow_queue_manager.WorkflowJob",
+            side_effect=RuntimeError("boom"),
+        ):
+            job = manager.add_workflow(item, cell_size_m=1000.0, analysis_scale="local")
+        self.assertIsNone(job)
+        self.assertEqual(item.getStatus(), "Workflow failed")
+        self.assertIn("boom", item.attribute("error", ""))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

One indicator with a broken or missing data source aborted the whole
multi-indicator run with a raw Python traceback. Now the queue manager traps
`WorkflowNotConfiguredError` **and** any unexpected exception at job creation:
the indicator's status icon flips to the failed icon, its tooltip explains the
problem in accessible language, the message bar names the indicator, and the
rest of the queue continues.

The config-validation raises in the multi-buffer native, point-per-cell and OSM
transport workflows now raise `WorkflowNotConfiguredError` with plain-language
messages instead of generic `Exception`/`ValueError`.

End-to-end regression tests: a broken layer declines with failed status +
tooltip while the next indicator still queues; an unexpected RuntimeError at
job creation is trapped rather than propagated. Full suite: 213 tests green on
QGIS 3.34 (Qt5) and QGIS 4.x (Qt6) docker images.

> Note: this branch is based on the #386 branch and shows its commits until
> #386 merges; the change specific to this PR is the top commit.

Fixes #399